### PR TITLE
Add Trajectory Visualization for at home autos

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,12 @@ targetCompatibility = JavaVersion.VERSION_11
 
 def ROBOT_MAIN_CLASS = "frc.robot.Main"
 
+repositories {
+    maven {
+        url "http://maven.came20.net/artifactory/devel"
+    }
+}
+
 // Define my targets (RoboRIO) and artifacts (deployable files)
 // This is added by GradleRIO's backing project EmbeddedTools.
 deploy {
@@ -57,6 +63,8 @@ dependencies {
     // Enable simulation gui support. Must check the box in vscode to enable support
     // upon debugging
     simulation wpi.deps.sim.gui(wpi.platforms.desktop, false)
+
+    implementation "frckit.tools:pathview:0.0.20"
 }
 
 // Setting up my Jar File. In this case, adding all libraries into the main jar ('fat jar')

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -31,7 +31,7 @@ public final class Constants {
         return robot;
     }
 
-    static void setRobot(RobotType robot) {
+    public static void setRobot(RobotType robot) {
         if (Constants.robot == null) {
             Constants.robot = robot;
         }

--- a/src/main/java/frc/robot/commands/RunGalacticSearchARed.java
+++ b/src/main/java/frc/robot/commands/RunGalacticSearchARed.java
@@ -13,6 +13,8 @@ import edu.wpi.first.wpilibj.geometry.Pose2d;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import frc.robot.subsystems.drive.DriveTrainBase;
+import frc.robot.Constants;
+import frc.robot.Constants.RobotType;
 import frc.robot.subsystems.RobotOdometry;
 
 // NOTE:  Consider using this command inline, rather than writing a subclass.  For more
@@ -20,12 +22,20 @@ import frc.robot.subsystems.RobotOdometry;
 // https://docs.wpilib.org/en/stable/docs/software/commandbased/convenience-features.html
 public class RunGalacticSearchARed extends SequentialCommandGroup {
 
+  NewRunMotionProfile mp;
+
   /** Creates a new RunGalacticSearchABlue. */
   public RunGalacticSearchARed(RobotOdometry odometry, DriveTrainBase driveTrain) {
+    mp = new NewRunMotionProfile(driveTrain, odometry, new Pose2d(30, 120, new Rotation2d()), 0,
+        List.of(new Translation2d(90, 90), new Translation2d(150, 60), new Translation2d(180, 150)),
+        new Pose2d(330, 150, new Rotation2d()), 0, false, false);
     // Add your addCommands(new FooCommand(), new BarCommand());
-    addCommands(new InstantCommand(() -> odometry.setPosition(new Pose2d(30, 120, new Rotation2d()))),
-        new RunMotionProfile(driveTrain, odometry, new Pose2d(30, 120, new Rotation2d()), 0,
-            List.of(new Translation2d(90, 90), new Translation2d(150, 60), new Translation2d(180, 150)),
-            new Pose2d(330, 150, new Rotation2d()), 0, false, false, false));
+    addCommands(new InstantCommand(() -> odometry.setPosition(new Pose2d(30, 120, new Rotation2d()))), mp);
+  }
+
+  public static void main(String[] args) {
+    Constants.setRobot(RobotType.ROBOT_2020);
+    RunGalacticSearchARed cmd = new RunGalacticSearchARed(null, null);
+    cmd.mp.visualize(2.0, List.of());
   }
 }


### PR DESCRIPTION
This brings in the viz from frckit into our NewRunMotionProfile command.  I also implemented the main method for one of the galactic search autos as a template.  This "ad-hoc" main method can be run straight from VSCode and will display the visualization window.

Note that I needed to make Constants.setRobot no longer package private so that appropriate trajectory values could be selected prior to visualization.